### PR TITLE
Basic Merkle Tree creation & check if contains hash

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,3 +4,5 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+hex = "0.4.3"
+sha3 = "0.10.8"

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,15 @@
-build:
-	cargo build
+.PHONY: run
 run:
 	cargo run
+
+.PHONY: build
+build:
+	cargo build
+
+.PHONY: clean
 clean:
 	cargo clean
+
+.PHONY: test
+test:
+	cargo test

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,32 +1,103 @@
-use std::hash::{DefaultHasher, Hash, Hasher};
+use sha3::{Digest, Keccak256};
 
-fn calculate_next_level(vec: &Vec<String>) -> Vec<String> {
-    let mut hasher = DefaultHasher::new();
+type MerkleTree = Vec<Vec<String>>;
+
+/// Checks if the given hash is present at any level of the Merkle Tree
+fn contains_hash(merkle: &MerkleTree, hash: &String) -> bool {
+    merkle.iter().any(|level| level.contains(hash))
+}
+
+/// Creates the next (upper) level for a Merkle Tree given the previous level.
+fn calculate_next_level(vec: &[String]) -> Vec<String> {
     let mut next_level: Vec<String> = vec![];
+    if vec.is_empty() {
+        return next_level;
+    }
     for i in (0..vec.len()-1).step_by(2) {
-        let s1 = vec[i].clone();
-        let s2 = vec[i+1].clone();
-        let s = String::from(format!("{s1}{s2}"));
-        s.hash(&mut hasher);
-        next_level.push(hasher.finish().to_string());
+        let hash = hash_multiple_str(vec![vec[i].clone(), vec[i+1].clone()]);
+        next_level.push(hash);
     }
     next_level
 }
 
-fn create_initial_level(vec: &Vec<i32>) -> Vec<String> {
-    let mut hasher = DefaultHasher::new();
-    vec.iter().map(|e| {
-        e.hash(&mut hasher);
-        hasher.finish().to_string()
-    }).collect()
+/// Creates the bottom level (leafs) for a Merkle Tree given a vector of u32
+fn create_initial_level(vec: &[u32]) -> Vec<String> {
+    let mut res: Vec<String> = vec![];
+    for &i in vec.iter() {
+        let hash = Keccak256::digest(i.to_le_bytes());
+        let hash = hex::encode(hash);
+        res.push(hash);
+    }
+    res
+}
+
+/// Creates a Merkle Tree given a vector of u32
+fn create_merkle_tree(vec: &[u32]) -> MerkleTree {
+    let initial = create_initial_level(vec);
+    let mut actual: Box<Vec<String>> = Box::new(initial);
+    let mut levels: MerkleTree = vec![];
+    levels.push(*actual.clone());
+    while actual.len() > 1 {
+        actual = Box::new(calculate_next_level(&actual));
+        levels.push(*actual.clone());
+    }
+    levels
+}
+
+/// Returns the digest for a single u32
+fn hash_one(n: u32) -> String {
+    hex::encode(Keccak256::digest(n.to_le_bytes()))
+}
+
+/// Returns the digest for several strings
+fn hash_multiple_str(vec: Vec<String>) -> String {
+    let mut hasher = Keccak256::new();
+    for s in vec.iter() {
+        sha3::Digest::update(&mut hasher, s);
+    }
+    hex::encode(hasher.finalize())
 }
 
 fn main() {
-    let initial = create_initial_level(&vec![3, 4, 5, 6]);
-    let mut actual: Box<Vec<String>> = Box::new(initial);
-    dbg!(&actual);
-    while (actual.len() > 1) {
-        actual = Box::new(calculate_next_level(&actual));
-        dbg!(&actual);
+    let tree = create_merkle_tree(&vec![3, 4, 5, 6, 9, 10, 2, 1]);
+    contains_hash(&tree, &hash_one(6));
+    dbg!(tree);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn hash_is_the_same() {
+        let first_hash = hash_one(32);
+        let second_hash = hash_one(32);
+        assert_eq!(first_hash, second_hash);
+    }
+
+    #[test]
+    fn test_creation_and_contains_hash() {
+        let tree = create_merkle_tree(&vec![3, 4, 5, 6]);
+        dbg!(&tree);
+
+        let three_hash = hash_one(3);
+        let four_hash = hash_one(4);
+        let threefour_hash = hash_multiple_str(vec![three_hash.clone(), four_hash.clone()]);
+
+        let five_hash = hash_one(5);
+        let six_hash = hash_one(6);
+        let fivesix_hash = hash_multiple_str(vec![five_hash.clone(), six_hash.clone()]);
+
+        let root = hash_multiple_str(vec![threefour_hash.clone(), fivesix_hash.clone()]);
+
+        assert!(contains_hash(&tree, &three_hash));
+        assert!(contains_hash(&tree, &four_hash));
+        assert!(contains_hash(&tree, &threefour_hash));
+        assert!(contains_hash(&tree, &five_hash));
+        assert!(contains_hash(&tree, &six_hash));
+        assert!(contains_hash(&tree, &fivesix_hash));
+        assert!(contains_hash(&tree, &root));
+
+        assert!(!contains_hash(&tree, &hash_one(7)));
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,32 @@
+use std::hash::{DefaultHasher, Hash, Hasher};
+
+fn calculate_next_level(vec: &Vec<String>) -> Vec<String> {
+    let mut hasher = DefaultHasher::new();
+    let mut next_level: Vec<String> = vec![];
+    for i in (0..vec.len()-1).step_by(2) {
+        let s1 = vec[i].clone();
+        let s2 = vec[i+1].clone();
+        let s = String::from(format!("{s1}{s2}"));
+        s.hash(&mut hasher);
+        next_level.push(hasher.finish().to_string());
+    }
+    next_level
+}
+
+fn create_initial_level(vec: &Vec<i32>) -> Vec<String> {
+    let mut hasher = DefaultHasher::new();
+    vec.iter().map(|e| {
+        e.hash(&mut hasher);
+        hasher.finish().to_string()
+    }).collect()
+}
+
 fn main() {
-    println!("Merkle Tree");
+    let initial = create_initial_level(&vec![3, 4, 5, 6]);
+    let mut actual: Box<Vec<String>> = Box::new(initial);
+    dbg!(&actual);
+    while (actual.len() > 1) {
+        actual = Box::new(calculate_next_level(&actual));
+        dbg!(&actual);
+    }
 }


### PR DESCRIPTION
This PR introduces the basic Merkle tree creation and the `contains_hash` function to check if a given hash is present in the tree. Some considerations:

- Not generic yet, it only works with an array of `u32` as argument.
- Only works with an array with length equal to a power of 2.
- Uses `sha3::Keccak256` for the hashing.
- Uses the `hex` crate for creating a hex string digest of the hash.
- Have not implemented any traits or defined a struct, the code structure is very basic.
- The `create_merkle_tree` function can possibly be made simpler.