### PR TITLE
Create tree from any integer type

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,11 @@ written in Rust.
 ## Running
 
 * Clone the repository `git clone git@github.com:dsocolobsky/merkle.git`
-* Run `make run`
+* `make run`
+* `make test`
 
 ## Implemented Features
-
+- Create a Merkle Tree from a list of integers of a size power of 2.
+- Add a new element to an existing Merkle Tree.
+- Create a proof that an element belongs to the Merkle Tree.
+- Given an element, index and a proof, verify it against a Merkle Tree.

--- a/src/serializable.rs
+++ b/src/serializable.rs
@@ -1,8 +1,8 @@
-/// Takes an integer type and it's size in bytes and implements Serializable for that type
+/// Takes an integer type, and it's size in bytes and implements Serializable for that type
 macro_rules! impl_serializable {
-    ($t:ty, $size:expr) => {
+    ($t:ty) => {
         impl Serializable for $t {
-            type Bytes = [u8; $size];
+            type Bytes = [u8; std::mem::size_of::<$t>()];
             fn to_le_bytes(&self) -> Self::Bytes {
                 <$t>::to_le_bytes(*self)
             }
@@ -16,14 +16,14 @@ pub trait Serializable {
     fn to_le_bytes(&self) -> Self::Bytes;
 }
 
-impl_serializable!(u8, 1);
-impl_serializable!(u16, 2);
-impl_serializable!(u32, 4);
-impl_serializable!(u64, 8);
-impl_serializable!(u128, 16);
+impl_serializable!(u8);
+impl_serializable!(u16);
+impl_serializable!(u32);
+impl_serializable!(u64);
+impl_serializable!(u128);
 
-impl_serializable!(i8, 1);
-impl_serializable!(i16, 2);
-impl_serializable!(i32, 4);
-impl_serializable!(i64, 8);
-impl_serializable!(i128, 16);
+impl_serializable!(i8);
+impl_serializable!(i16);
+impl_serializable!(i32);
+impl_serializable!(i64);
+impl_serializable!(i128);

--- a/src/serializable.rs
+++ b/src/serializable.rs
@@ -1,0 +1,29 @@
+/// Takes an integer type and it's size in bytes and implements Serializable for that type
+macro_rules! impl_serializable {
+    ($t:ty, $size:expr) => {
+        impl Serializable for $t {
+            type Bytes = [u8; $size];
+            fn to_le_bytes(&self) -> Self::Bytes {
+                <$t>::to_le_bytes(*self)
+            }
+        }
+    };
+}
+
+/// Trait for numeric types that can be serialized to a sequence of bytes
+pub trait Serializable {
+    type Bytes: AsRef<[u8]>;
+    fn to_le_bytes(&self) -> Self::Bytes;
+}
+
+impl_serializable!(u8, 1);
+impl_serializable!(u16, 2);
+impl_serializable!(u32, 4);
+impl_serializable!(u64, 8);
+impl_serializable!(u128, 16);
+
+impl_serializable!(i8, 1);
+impl_serializable!(i16, 2);
+impl_serializable!(i32, 4);
+impl_serializable!(i64, 8);
+impl_serializable!(i128, 16);


### PR DESCRIPTION
This PR allows to create a Merkle Tree from any integer type (`u8..u128` and `i8..i128`) instead of just `u32` like before.
