### PR TITLE
Allow creation of tree with odd number of elements & fix adding a new element

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -191,12 +191,6 @@ fn hash_multiple(hashes: &[Hash]) -> Hash {
     hasher.finalize().into()
 }
 
-/// Returns if a number is power of 2, or 0
-// In this case considering 0 as a power of 2 is useful.
-fn is_power_of_2(n: usize) -> bool {
-    (n & (n - 1)) == 0
-}
-
 fn main() {
     let mut tree = MerkleTree::create_from_values(vec![3, 4, 5, 6, 11, 10, 2, 1]);
     dbg!(&tree);


### PR DESCRIPTION
- You can now create a tree with an odd number of elements, it will duplicate the last hash in the leafs level and then build up from that.
- The logic for adding a new element to an existing tree is now fixed, previously it would miss some intermediate nodes, now it should work.
- Simplified the `create_from_values` function.
- Added tests

There are some clippy warnings but I'm fixing them in a separate PR because a lot of them are unrelated to these changes.