### PR TITLE
Fix Clippy warnings

### DIFF
--- a/src/serializable.rs
+++ b/src/serializable.rs
@@ -11,6 +11,9 @@ macro_rules! impl_serializable {
 }
 
 /// Trait for numeric types that can be serialized to a sequence of bytes
+/// We need this because there's no trait to determine which types implement
+/// .to_le_bytes() or similar, even though all integer types do that already.
+/// With this trait we can call .to_le_bytes() in all integers specified in the macros in order to hash them.
 pub trait Serializable {
     type Bytes: AsRef<[u8]>;
     fn to_le_bytes(&self) -> Self::Bytes;


### PR DESCRIPTION
Fixes all clippy warnings and also simplifies a bit the code by making `create_from_values` take a `&[T]` as a parameter instead of a `&Vec<T>`.